### PR TITLE
chore: download pkger in update-to-head.sh

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -40,6 +40,7 @@ git checkout upstream/main -B release-next
 # Update openshift's main and take all needed files from there.
 git fetch openshift main
 git checkout openshift/main $custom_files
+go get github.com/markbates/pkger/cmd/pkger
 pkger
 git add $custom_files pkged.go
 git commit -m "${openshift_files_msg}"


### PR DESCRIPTION
Adding pkger binary download in order to avoid `pkger` not found error