### PR TITLE
Fix module name in plugin version

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -38,7 +38,7 @@ func (f *funcPlugin) Execute(args []string) error {
 	rootCmd, _ := cmd.NewRootCmd()
 	info, _ := debug.ReadBuildInfo()
 	for _, dep := range info.Deps {
-		if strings.Contains(dep.Path, "knative-sandbox/kn-plugin-func") {
+		if strings.Contains(dep.Path, "knative.dev/kn-plugin-func") {
 			cmd.SetMeta("", dep.Version, dep.Sum)
 		}
 	}


### PR DESCRIPTION
Sorry about that I was too hash to fix yesterday. That's the real fix. 

```
➜  client git:(release-v0.24.0) ✗ kn func version
v0.18.0
```

/cc @lance 