### PR TITLE
chore: remove red hat builders

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -27,7 +27,6 @@ REPO_NAME=$(basename $(git rev-parse --show-toplevel))
 # Custom files
 custom_files=$(cat <<EOT | tr '\n' ' '
 openshift
-templates
 EOT
 )
 openshift_files_msg=":open_file_folder: update OpenShift specific files"

--- a/templates/go/manifest.yaml
+++ b/templates/go/manifest.yaml
@@ -1,2 +1,0 @@
-builders:
-  default: quay.io/boson/faas-go-builder

--- a/templates/node/manifest.yaml
+++ b/templates/node/manifest.yaml
@@ -1,2 +1,0 @@
-builders:
-  default: quay.io/boson/faas-nodejs-builder

--- a/templates/typescript/manifest.yaml
+++ b/templates/typescript/manifest.yaml
@@ -1,2 +1,0 @@
-builders:
-  default: quay.io/boson/faas-nodejs-builder


### PR DESCRIPTION
This commit removes any mid-stream red hat builders in favor of upstream
paketo, until red hat has an appropriate builder strategy for products.

/cc @nainaz 

Signed-off-by: Lance Ball <lball@redhat.com>