### PR TITLE
Use boson buildpacks for Quarkus

### DIFF
--- a/templates/quarkus/cloudevents/src/main/resources/application.properties
+++ b/templates/quarkus/cloudevents/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.funqy.export=function
+quarkus.package.type=legacy-jar
+quarkus.smallrye-health.root-path=/health
+quarkus.smallrye-health.liveness-path=liveness
+quarkus.smallrye-health.readiness-path=readiness

--- a/templates/quarkus/http/src/main/resources/application.properties
+++ b/templates/quarkus/http/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.funqy.export=function
+quarkus.package.type=legacy-jar
+quarkus.smallrye-health.root-path=/health
+quarkus.smallrye-health.liveness-path=liveness
+quarkus.smallrye-health.readiness-path=readiness

--- a/templates/quarkus/manifest.yaml
+++ b/templates/quarkus/manifest.yaml
@@ -1,0 +1,9 @@
+builders:
+  default: quay.io/boson/faas-jvm-builder:latest
+  jvm: quay.io/boson/faas-jvm-builder:latest
+  native: quay.io/boson/faas-quarkus-native-builder:latest
+buildEnvs:
+  - name: MAVEN_S2I_ARTIFACT_DIRS
+    value: target
+  - name: S2I_SOURCE_DEPLOYMENTS_FILTER
+    value: "*-runner.jar lib"


### PR DESCRIPTION
* Use boson (downstream, non-paketo) buildpack.
* Force legacy-jar packaging until boson buildpack support fast-jar packaging.

Signed-off-by: Matej Vasek <mvasek@redhat.com>