### PR TITLE
Add patch for on-cluster build git-clone as ClusterTask

### DIFF
--- a/openshift/patches/0004-tekton-tasks.patch
+++ b/openshift/patches/0004-tekton-tasks.patch
@@ -1,0 +1,28 @@
+diff --git a/pipelines/tekton/tasks.go b/pipelines/tekton/tasks.go
+index 5e714b21..ffd29cca 100644
+--- a/pipelines/tekton/tasks.go
++++ b/pipelines/tekton/tasks.go
+@@ -2,6 +2,7 @@ package tekton
+
+ import (
+ 	pplnv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
++	"knative.dev/kn-plugin-func/openshift"
+ )
+
+ const (
+@@ -11,10 +12,15 @@ const (
+ )
+
+ func taskFetchSources() pplnv1beta1.PipelineTask {
++	var taskKind = pplnv1beta1.NamespacedTaskKind
++	if openshift.IsOpenShift() {
++		taskKind = pplnv1beta1.ClusterTaskKind
++	}
+ 	return pplnv1beta1.PipelineTask{
+ 		Name: taskNameFetchSources,
+ 		TaskRef: &pplnv1beta1.TaskRef{
+ 			Name: "git-clone",
++			Kind: taskKind,
+ 		},
+ 		Workspaces: []pplnv1beta1.WorkspacePipelineTaskBinding{{
+ 			Name:      "output",


### PR DESCRIPTION
This patch allows on-cluters builds to proceed properly on OCP using the`git-clone` (cluster wide) task pre-installed with Openshift Pipelines.