### PR TITLE
[serverless-1.23.0] Cherry-pick upstream fixes

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -21,7 +21,5 @@ jobs:
         run: ./hack/allocate.sh
       - name: Local Registry
         run: ./hack/registry.sh
-      - name: Verify Configuration
-        run: ./hack/test.sh
       - name: Integration Test
         run: make test-integration

--- a/buildpacks/builder_test.go
+++ b/buildpacks/builder_test.go
@@ -1,0 +1,121 @@
+package buildpacks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pack "github.com/buildpacks/pack/pkg/client"
+	fn "knative.dev/kn-plugin-func"
+	. "knative.dev/kn-plugin-func/testing"
+)
+
+// Test_ErrRuntimeRequired ensures that a request to build without a runtime
+// defined for the Function yields an ErrRuntimeRequired
+func Test_ErrRuntimeRequired(t *testing.T) {
+	b := NewBuilder()
+	err := b.Build(context.Background(), fn.Function{})
+
+	if !errors.As(err, &ErrRuntimeRequired{}) {
+		t.Fatalf("expected ErrRuntimeRequired not received. Got %v", err)
+	}
+}
+
+// Test_ErrRuntimeNotSupported ensures that a request to build a function whose
+// runtime is not yet supported yields an ErrRuntimeNotSupported
+func Test_ErrRuntimeNotSupported(t *testing.T) {
+	b := NewBuilder()
+	err := b.Build(context.Background(), fn.Function{Runtime: "unsupported"})
+
+	if !errors.As(err, &ErrRuntimeNotSupported{}) {
+		t.Fatalf("expected ErrRuntimeNotSupported not received. got %v", err)
+	}
+}
+
+// Test_ImageDefault ensures that a Function bing built which does not
+// define a Builder Image will get the internally-defined default.
+func Test_ImageDefault(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "node"}
+	)
+
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		expected := DefaultBuilderImages["node"]
+		if opts.Builder != expected {
+			t.Fatalf("expected pack builder image '%v', got '%v'", expected, opts.Builder)
+		}
+		return nil
+	}
+
+	if err := b.Build(context.Background(), f); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+// Test_BuilderImageConfigurable ensures that the builder will use the builder
+// image defined on the given Function if provided.
+func Test_BuilderImageConfigurable(t *testing.T) {
+	var (
+		i = &mockImpl{}             // mock underlying implementation
+		b = NewBuilder(WithImpl(i)) // Func Builder logic
+		f = fn.Function{            // Function with a builder image set
+			Runtime: "node",
+			BuilderImages: map[string]string{
+				"pack": "example.com/user/builder-image",
+			},
+		}
+	)
+
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		expected := f.BuilderImages["pack"]
+		if opts.Builder != expected {
+			t.Fatalf("expected builder image for node to be '%v', got '%v'", expected, opts.Builder)
+		}
+		return nil
+	}
+
+	if err := b.Build(context.Background(), f); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test_BuildEnvs ensures that build environment variables are interpolated and
+// provided in Build Options
+func Test_BuildEnvs(t *testing.T) {
+	defer WithEnvVar(t, "INTERPOLATE_ME", "interpolated")()
+	var (
+		envName  = "NAME"
+		envValue = "{{ env:INTERPOLATE_ME }}"
+		f        = fn.Function{
+			Runtime:   "node",
+			BuildEnvs: []fn.Env{{Name: &envName, Value: &envValue}},
+		}
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+	)
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		for k, v := range opts.Env {
+			if k == envName && v == "interpolated" {
+				return nil // success!
+			} else if k == envName && v == envValue {
+				t.Fatal("build env was not interpolated")
+			}
+		}
+		t.Fatal("build envs not added to builder options")
+		return nil
+	}
+	if err := b.Build(context.Background(), f); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type mockImpl struct {
+	BuildFn func(context.Context, pack.BuildOptions) error
+}
+
+func (i mockImpl) Build(ctx context.Context, opts pack.BuildOptions) error {
+	return i.BuildFn(ctx, opts)
+}

--- a/client.go
+++ b/client.go
@@ -557,18 +557,6 @@ func (c *Client) Create(cfg Function) (err error) {
 		return
 	}
 
-	// TODO: Create a status structure and return it for clients to use
-	// for output, such as from the CLI.
-	if c.verbose {
-		fmt.Printf("Builder:       %s\n", f.Builder)
-		if len(f.Buildpacks) > 0 {
-			fmt.Println("Buildpacks:")
-			for _, b := range f.Buildpacks {
-				fmt.Printf("           ... %s\n", b)
-			}
-		}
-		fmt.Println("Function project created")
-	}
 	return
 }
 

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -203,7 +203,7 @@ func TestRemoteRepositories(t *testing.T) {
 // newClient creates an instance of the func client whose concrete impls
 // match those created by the kn func plugin CLI.
 func newClient(verbose bool) *fn.Client {
-	builder := buildpacks.NewBuilder(verbose)
+	builder := buildpacks.NewBuilder(buildpacks.WithVerbose(verbose))
 	pusher := docker.NewPusher(docker.WithVerbose(verbose))
 	deployer := knative.NewDeployer(DefaultNamespace, verbose)
 	remover := knative.NewRemover(DefaultNamespace, verbose)

--- a/client_test.go
+++ b/client_test.go
@@ -899,8 +899,8 @@ func TestClient_Deploy_UnbuiltErrors(t *testing.T) {
 	}
 }
 
-// TestClient_New_BuildersPersisted Asserts that the client preserves user-
-// provided Builders
+// TestClient_New_BuilderImagesPersisted Asserts that the client preserves user-
+// provided Builder Images
 func TestClient_New_BuildersPersisted(t *testing.T) {
 	root := "testdata/example.com/testConfiguredBuilders" // Root from which to run the test
 	defer Using(t, root)()
@@ -910,8 +910,9 @@ func TestClient_New_BuildersPersisted(t *testing.T) {
 	f0 := fn.Function{
 		Runtime: TestRuntime,
 		Root:    root,
-		Builders: map[string]string{
-			"custom": "docker.io/example/custom",
+		BuilderImages: map[string]string{
+			"pack": "example.com/my/custom-pack-builder",
+			"s2i":  "example.com/my/custom-s2i-builder",
 		}}
 
 	// Create the Function, which should preserve custom builders
@@ -926,8 +927,8 @@ func TestClient_New_BuildersPersisted(t *testing.T) {
 	}
 
 	// Assert that our custom builders were retained
-	if !reflect.DeepEqual(f0.Builders, f1.Builders) {
-		t.Fatalf("Expected %v but got %v", f0.Builders, f1.Builders)
+	if !reflect.DeepEqual(f0.BuilderImages, f1.BuilderImages) {
+		t.Fatalf("Expected %v but got %v", f0.BuilderImages, f1.BuilderImages)
 	}
 
 	// A Default Builder(image) is not asserted here, because that is
@@ -935,41 +936,6 @@ func TestClient_New_BuildersPersisted(t *testing.T) {
 	// The builder (Buildpack,s2i, etc) will have a default builder image for
 	// the given Function or will error that the Function is not supported.
 	// A builder image may also be manually specified of course.
-}
-
-// TestClient_New_BuilderDefault ensures that if a custom builder is
-// provided of name "default", this is chosen as the default builder instead
-// of the inbuilt static default.
-func TestClient_New_BuilderDefault(t *testing.T) {
-	root := "testdata/example.com/testConfiguredBuildersWithDefault" // Root from which to run the test
-	defer Using(t, root)()
-
-	builders := map[string]string{
-		"custom":  "docker.io/example/custom",
-		"default": "docker.io/example/default",
-	}
-	client := fn.New(fn.WithRegistry(TestRegistry))
-	if err := client.New(context.Background(), fn.Function{
-		Runtime:  TestRuntime,
-		Root:     root,
-		Builders: builders,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	f, err := fn.NewFunction(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Assert that our custom builder array was set
-	if !reflect.DeepEqual(f.Builders, builders) {
-		t.Fatalf("Expected %v but got %v", builders, f.Builders)
-	}
-
-	// Asser that the default is also set
-	if f.Builder != builders["default"] {
-		t.Fatalf("Expected %s but got %s", builders["default"], f.Builder)
-	}
 }
 
 // TestClient_New_BuildpacksPersisted ensures that provided buildpacks are

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -158,7 +158,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 	// Choose a builder based on the value of the --builder flag
 	var builder fn.Builder
 	if config.Builder == "pack" {
-		builder = buildpacks.NewBuilder(config.Verbose)
+		builder = buildpacks.NewBuilder(buildpacks.WithVerbose(config.Verbose))
 	} else if config.Builder == "s2i" {
 		builder = s2i.NewBuilder(s2i.WithVerbose(config.Verbose))
 	} else {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -100,7 +100,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		return
 	}
 
-	function, err := functionWithOverrides(config.Path, functionOverrides{BuilderImage: config.BuilderImage, Image: config.Image})
+	function, err := functionWithOverrides(config.Path, functionOverrides{Image: config.Image})
 	if err != nil {
 		return
 	}
@@ -164,6 +164,11 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 	} else {
 		err = errors.New("unrecognized builder: valid values are: s2i, pack")
 		return
+	}
+
+	// Use the user-provided builder image, if supplied
+	if config.BuilderImage != "" {
+		function.BuilderImages[config.Builder] = config.BuilderImage
 	}
 
 	// Create a client using the registry defined in config plus any additional

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -68,7 +68,7 @@ func NewClient(cfg ClientConfig, options ...fn.Option) (*fn.Client, func()) {
 			fn.WithVerbose(cfg.Verbose),
 			fn.WithProgressListener(p),
 			fn.WithTransport(t),
-			fn.WithBuilder(buildpacks.NewBuilder(cfg.Verbose)),
+			fn.WithBuilder(buildpacks.NewBuilder(buildpacks.WithVerbose(cfg.Verbose))),
 			fn.WithRemover(knative.NewRemover(cfg.Namespace, cfg.Verbose)),
 			fn.WithDescriber(knative.NewDescriber(cfg.Namespace, cfg.Verbose)),
 			fn.WithLister(knative.NewLister(cfg.Namespace, cfg.Verbose)),

--- a/cmd/completion_util.go
+++ b/cmd/completion_util.go
@@ -114,8 +114,8 @@ func CompleteBuilderImageList(cmd *cobra.Command, args []string, complete string
 		return
 	}
 
-	builderImages = make([]string, 0, len(f.Builders))
-	for name := range f.Builders {
+	builderImages = make([]string, 0, len(f.BuilderImages))
+	for name := range f.BuilderImages {
 		if len(complete) == 0 {
 			builderImages = append(builderImages, name)
 			continue

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,9 +168,8 @@ func bindEnv(flags ...string) bindFunc {
 }
 
 type functionOverrides struct {
-	Image        string
-	Namespace    string
-	BuilderImage string
+	Image     string
+	Namespace string
 }
 
 // functionWithOverrides sets the namespace and image strings for the
@@ -187,7 +186,6 @@ func functionWithOverrides(root string, overrides functionOverrides) (f fn.Funct
 		src  string
 		dest *string
 	}{
-		{overrides.BuilderImage, &f.Builder},
 		{overrides.Image, &f.Image},
 		{overrides.Namespace, &f.Namespace},
 	}

--- a/function.go
+++ b/function.go
@@ -64,15 +64,9 @@ type Function struct {
 	// in case build type "git" is being used
 	Git Git `yaml:"git"`
 
-	// Builder represents the CNCF Buildpack builder image for a function
-	Builder string `yaml:"builder"`
-
-	// Map containing known builders.
-	// e.g. { "jvm": "docker.io/example/quarkus-jvm-builder" }
-	Builders map[string]string `yaml:"builders"`
-
 	// BuilderImages define optional explicit builder images to use by
-	// builder implementations in leau of the in-code defaults.
+	// builder implementations in leau of the in-code defaults.  They key
+	// is the builder's short name.  For example:
 	// builderImages:
 	//   pack: example.com/user/my-pack-node-builder
 	//   s2i: example.com/user/my-s2i-node-builder
@@ -121,8 +115,8 @@ type HealthEndpoints struct {
 
 // BuildConfig defines builders and buildpacks
 type BuildConfig struct {
-	Buildpacks []string          `yaml:"buildpacks,omitempty"`
-	Builders   map[string]string `yaml:"builders,omitempty"`
+	Buildpacks    []string          `yaml:"buildpacks,omitempty"`
+	BuilderImages map[string]string `yaml:"builderImages,omitempty"`
 }
 
 // Invocation defines hints on how to accomplish a Function invocation.
@@ -169,7 +163,7 @@ func NewFunction(path string) (f Function, err error) {
 	if err != nil {
 		return
 	}
-	if err = yaml.UnmarshalStrict(bb, &f); err != nil {
+	if err = yaml.Unmarshal(bb, &f); err != nil {
 		err = formatUnmarshalError(err) // human-friendly unmarshalling errors
 		return
 	}
@@ -486,7 +480,7 @@ func hasInitializedFunction(path string) (bool, error) {
 		return false, err
 	}
 	f := Function{}
-	if err = yaml.UnmarshalStrict(bb, &f); err != nil {
+	if err = yaml.Unmarshal(bb, &f); err != nil {
 		return false, err
 	}
 	if f, err = f.Migrate(); err != nil {

--- a/pipelines/tekton/resources.go
+++ b/pipelines/tekton/resources.go
@@ -125,7 +125,7 @@ func generatePipelineRun(f fn.Function, labels map[string]string) *pplnv1beta1.P
 				},
 				{
 					Name:  "builderImage",
-					Value: *pplnv1beta1.NewArrayOrString(buildpacks.BuilderImage(f)),
+					Value: *pplnv1beta1.NewArrayOrString(getBuilderImage(f)),
 				},
 			},
 
@@ -153,6 +153,15 @@ func generatePipelineRun(f fn.Function, labels map[string]string) *pplnv1beta1.P
 			},
 		},
 	}
+}
+
+// guilderImage returns the builder image to use when building the Function
+// with the Pack strategy if it can be calculated (the Function has a defined
+// language runtime.  Errors are checked elsewhere, so at this level they
+// manifest as an inability to get a builder image = empty string.
+func getBuilderImage(f fn.Function) (name string) {
+	name, _ = buildpacks.BuilderImage(f)
+	return
 }
 
 func getPipelineName(f fn.Function) string {

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -29,8 +29,6 @@
 				"imageDigest",
 				"build",
 				"git",
-				"builder",
-				"builders",
 				"buildpacks",
 				"volumes",
 				"buildEnvs",
@@ -74,17 +72,6 @@
 				"git": {
 					"$schema": "http://json-schema.org/draft-04/schema#",
 					"$ref": "#/definitions/Git"
-				},
-				"builder": {
-					"type": "string"
-				},
-				"builders": {
-					"patternProperties": {
-						".*": {
-							"type": "string"
-						}
-					},
-					"type": "object"
 				},
 				"builderImages": {
 					"patternProperties": {

--- a/template.go
+++ b/template.go
@@ -37,14 +37,8 @@ func (t template) Write(ctx context.Context, f *Function) error {
 	// so it's values are treated as defaults.
 	// TODO: this begs the question: should the Template's manifest.yaml actually
 	// be a partially-populated func.yaml?
-	if f.Builder == "" { // as a special first case, this default comes from itself
-		f.Builder = f.Builders["default"]
-		if f.Builder == "" { // still nothing?  then use the template
-			f.Builder = t.config.Builders["default"]
-		}
-	}
-	if len(f.Builders) == 0 {
-		f.Builders = t.config.Builders
+	if len(f.BuilderImages) == 0 {
+		f.BuilderImages = t.config.BuilderImages
 	}
 	if len(f.Buildpacks) == 0 {
 		f.Buildpacks = t.config.Buildpacks

--- a/testdata/migrations/v0.23.0-customized/func.yaml
+++ b/testdata/migrations/v0.23.0-customized/func.yaml
@@ -1,0 +1,26 @@
+version: 0.0.0
+name: testfunc
+namespace: ""
+runtime: go
+registry: ""
+image: ""
+imageDigest: ""
+build: local
+git: {}
+builder: "example.com/user/custom-builder"
+builders: {}
+buildpacks:
+- paketo-buildpacks/go-dist
+- ghcr.io/boson-project/go-function-buildpack:tip
+volumes: []
+buildEnvs: []
+envs: []
+annotations: {}
+options: {}
+labels: []
+healthEndpoints:
+  liveness: /health/liveness
+  readiness: /health/readiness
+created: 2022-05-25T22:44:47.36886+09:00
+invocation:
+  format: http

--- a/testdata/migrations/v0.23.0/func.yaml
+++ b/testdata/migrations/v0.23.0/func.yaml
@@ -1,0 +1,26 @@
+version: 0.0.0
+name: testfunc
+namespace: ""
+runtime: go
+registry: ""
+image: ""
+imageDigest: ""
+build: local
+git: {}
+builder: ""
+builders: {}
+buildpacks:
+- paketo-buildpacks/go-dist
+- ghcr.io/boson-project/go-function-buildpack:tip
+volumes: []
+buildEnvs: []
+envs: []
+annotations: {}
+options: {}
+labels: []
+healthEndpoints:
+  liveness: /health/liveness
+  readiness: /health/readiness
+created: 2022-05-25T22:44:47.36886+09:00
+invocation:
+  format: http


### PR DESCRIPTION
Changes:

```
7379b6ff Fix premature Close() of docker client (#1057)
63d6ca12 [release-0.24] feat: builder images map migration (#1045)
38de9d69 remove third-party echo test from CI (#1055)
561930cd feat: pack builder images individually configurable (#1044)
```