### PR TITLE
patch for e2e tests on ci

### DIFF
--- a/openshift/patches/0004-ci-e2e-runtime.patch
+++ b/openshift/patches/0004-ci-e2e-runtime.patch
@@ -1,0 +1,13 @@
+diff --git a/.github/workflows/test-e2e-runtime.yaml b/.github/workflows/test-e2e-runtime.yaml
+index b6a6c485..e24eb458 100644
+--- a/.github/workflows/test-e2e-runtime.yaml
++++ b/.github/workflows/test-e2e-runtime.yaml
+@@ -11,7 +11,7 @@ jobs:
+     name: E2E Test
+     strategy:
+       matrix:
+-        runtime: ["go", "python", "quarkus", "springboot", "typescript"]
++        runtime: ["quarkus", "typescript"]
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v2


### PR DESCRIPTION
Patch to be applied on ci in order to fix e2e execution error. Since default builder is s2i, runtimes not supported by s2i fails and cause other to not run. Example https://github.com/openshift-knative/kn-plugin-func/runs/7717020997?check_suite_focus=true#step:8:13 

