### PR TITLE
update quarkus patch to match upstream

### DIFF
--- a/openshift/patches/0003-quarkus-productized.patch
+++ b/openshift/patches/0003-quarkus-productized.patch
@@ -7,7 +7,7 @@ index 2bc2df55..e18ac0f3 100644
      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
      <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 -    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
--    <quarkus.platform.version>2.10.3.Final</quarkus.platform.version>
+-    <quarkus.platform.version>2.11.2.Final</quarkus.platform.version>
 +    <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
 +    <quarkus.platform.version>2.7.6.Final-redhat-00006</quarkus.platform.version>
      <skipITs>true</skipITs>
@@ -56,7 +56,7 @@ index 2bc2df55..e18ac0f3 100644
      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
      <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 -    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
--    <quarkus.platform.version>2.10.3.Final</quarkus.platform.version>
+-    <quarkus.platform.version>2.11.2.Final</quarkus.platform.version>
 +    <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
 +    <quarkus.platform.version>2.7.6.Final-redhat-00006</quarkus.platform.version>
      <skipITs>true</skipITs>


### PR DESCRIPTION
This change alings the git patch with the actual quarkus template, updated recently by quarkus bot on upstream
https://github.com/knative-sandbox/kn-plugin-func/commit/849c2cd7a187d37693ba963b6cd1fc9a0377ad4d
