### PR TITLE
chore: patch string verbose

### DIFF
--- a/openshift/patches/0006-version.patch
+++ b/openshift/patches/0006-version.patch
@@ -1,0 +1,26 @@
+diff --git a/cmd/root.go b/cmd/root.go
+index 2533f822..18063874 100644
+--- a/cmd/root.go
++++ b/cmd/root.go
+@@ -12,6 +12,7 @@ import (
+ 
+ 	"knative.dev/func/cmd/templates"
+ 	"knative.dev/func/config"
++	"knative.dev/func/k8s"
+ 
+ 	"github.com/ory/viper"
+ 	"github.com/spf13/cobra"
+@@ -383,7 +384,12 @@ func (v Version) StringVerbose() string {
+ 	if date == "" {
+ 		date = time.Now().Format(time.RFC3339)
+ 	}
+-	return fmt.Sprintf("%s-%s-%s", vers, hash, date)
++	funcVersion := fmt.Sprintf("%s-%s-%s", vers, hash, date)
++	return fmt.Sprintf("Version: %s\n" +
++		"SocatImage: %s\n" +
++		"TarImage: %s", funcVersion,
++		k8s.SocatImage,
++		k8s.TarImage)
+ }
+ 
+ // surveySelectDefault returns 'value' if defined and exists in 'options'.


### PR DESCRIPTION
* Adding a patch to display related images for command `kn func version --verbose`

Output would look similar to:
```
$ kn func version --verbose
Version: v0.0.0-source-2022-11-15T13:44:42-03:00
SocatImage: registry.redhat.io/openshift-serverless-1/func-socat-rhel8@sha256:395f5f2dc8995c014f64636494193414ca9f24a5b4a80e03ad280832580086ba
TarImage: registry.redhat.io/openshift-serverless-1/func-socat-rhel8@sha256:395f5f2dc8995c014f64636494193414ca9f24a5b4a80e03ad280832580086ba
```