### PR TITLE
fix: update openshift pipelines hack script operator wait condition

### DIFF
--- a/openshift/overrides/hack/openshift-pipelines.sh
+++ b/openshift/overrides/hack/openshift-pipelines.sh
@@ -45,7 +45,9 @@ EOF
 
   sleep 10
   oc wait subscription.operators.coreos.com/openshift-pipelines-operator-rh -n openshift-operators --for=jsonpath='{.status.state}'="AtLatestKnown" --timeout=60s
-  sleep 60
+  oc wait pod --for=condition=Ready --timeout=180s -n openshift-pipelines -l "app=tekton-pipelines-controller"
+  oc wait pod --for=condition=Ready --timeout=180s -n openshift-pipelines -l "app=tekton-pipelines-webhook"
+  sleep 10
 
 }
 


### PR DESCRIPTION
This PR adds 2 new wait condition for openshift pipelines operator install (used for e2e tests, on QE repo). Sometimes tasks fails to install due webhook or controller not yet ready. The 2 additional conditions aligns with tekton wait condition on upstream.