### PR TITLE
chore: update quarkus patch to 2.16.2

### DIFF
--- a/openshift/patches/0003-quarkus-productized.patch
+++ b/openshift/patches/0003-quarkus-productized.patch
@@ -12,7 +12,7 @@ index 58abbb0a..f71561e3 100644
      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
      <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 -    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
--    <quarkus.platform.version>2.16.1.Final</quarkus.platform.version>
+-    <quarkus.platform.version>2.16.2.Final</quarkus.platform.version>
 +    <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
 +    <quarkus.platform.version>2.13.5.SP1-redhat-00002</quarkus.platform.version>
      <skipITs>true</skipITs>
@@ -63,7 +63,7 @@ index 58abbb0a..f71561e3 100644
      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
      <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 -    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
--    <quarkus.platform.version>2.16.1.Final</quarkus.platform.version>
+-    <quarkus.platform.version>2.16.2.Final</quarkus.platform.version>
 +    <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
 +    <quarkus.platform.version>2.13.5.SP1-redhat-00002</quarkus.platform.version>
      <skipITs>true</skipITs>


### PR DESCRIPTION
upstream patch https://github.com/knative/func/pull/1538