### PR TITLE
fix update-to-head script with correct make target for zz_fileystem_generated.go

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -51,7 +51,7 @@ if [[ -d openshift/overrides ]]; then
 fi
 git add .
 
-make zz_filesystem_generated.go
+make generate/zz_filesystem_generated.go
 git add $custom_files zz_filesystem_generated.go
 git commit -m "${openshift_files_msg}"
 


### PR DESCRIPTION
This PR is to accommodate this upstream change: 
https://github.com/knative/func/pull/1554/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L91 
