### PR TITLE
[serverless-1.28.0] patch func-deploy task to midstream specific impletementation

### DIFF
--- a/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,7 +24,17 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "ghcr.io/knative/func/func:latest"
-      script: |
-        export FUNC_IMAGE="$(params.image)"
-        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:59858828680d052d1f51f959a64c46afae61939b18d6bddc1f4dfb1ac68c43c0"
+      env:
+        - name: FUNC_IMAGE
+          value: "$(params.image)"
+      command:
+        - /ko-app/kn
+      args:
+        - func
+        - deploy
+        - --verbose
+        - --build=false
+        - --push=false
+        - --path=$(params.path)
+        - --remote=false


### PR DESCRIPTION
Patching func-deploy task to use midstream specific kn client image.