### PR TITLE
[serverless-1.29.0] clustertask patch for devconsole create serverless function

### DIFF
--- a/pkg/pipelines/resources/tekton/pipeline/dev-console/0.1/nodejs-pipeline.yaml
+++ b/pkg/pipelines/resources/tekton/pipeline/dev-console/0.1/nodejs-pipeline.yaml
@@ -1,0 +1,91 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: devconsole-nodejs-function-pipeline
+  namespace: openshift
+  labels:
+    function.knative.dev: "true"
+    function.knative.dev/name: viewer
+    function.knative.dev/runtime: nodejs
+spec:
+  params:
+    - description: Git repository that hosts the function project
+      name: GIT_REPO
+      type: string
+    - description: Git revision to build
+      name: GIT_REVISION
+      type: string
+    - description: Path where the function project is
+      name: PATH_CONTEXT
+      type: string
+      default: .
+    - description: Function image name
+      name: IMAGE_NAME
+      type: string
+    - description: Builder image to be used
+      name: BUILDER_IMAGE
+      type: string
+      default: image-registry.openshift-image-registry.svc:5000/openshift/nodejs:16-ubi8
+    - description: Environment variables to set during build time
+      name: BUILD_ENVS
+      type: array
+      default: []
+    - default: 'image:///usr/libexec/s2i'
+      description: >-
+        URL containing the default assemble and run scripts for the builder
+        image.
+      name: s2iImageScriptsUrl
+      type: string
+  resources: []
+  workspaces:
+    - description: Directory where function source is located.
+      name: source-workspace
+  tasks:
+    - name: fetch-sources
+      params:
+        - name: url
+          value: $(params.GIT_REPO)
+        - name: revision
+          value: $(params.GIT_REVISION)
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: source-workspace
+    - name: build
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE_NAME)
+        - name: PATH_CONTEXT
+          value: $(params.PATH_CONTEXT)
+        - name: BUILDER_IMAGE
+          value: $(params.BUILDER_IMAGE)
+        - name: ENV_VARS
+          value:
+            - '$(params.BUILD_ENVS[*])'
+        - name: S2I_IMAGE_SCRIPTS_URL
+          value: $(params.s2iImageScriptsUrl)
+      runAfter:
+        - fetch-sources
+      taskRef:
+        kind: ClusterTask
+        name: func-s2i
+      workspaces:
+        - name: source
+          workspace: source-workspace
+    - name: deploy
+      params:
+        - name: path
+          value: $(workspaces.source.path)/$(params.PATH_CONTEXT)
+        - name: image
+          value: $(params.IMAGE_NAME)@$(tasks.build.results.IMAGE_DIGEST)
+      runAfter:
+        - build
+      taskRef:
+        kind: ClusterTask
+        name: func-deploy
+      workspaces:
+        - name: source
+          workspace: source-workspace
+  finally: []

--- a/pkg/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: Task
+kind: ClusterTask
 metadata:
   name: func-buildpacks
   labels:

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: Task
+kind: ClusterTask
 metadata:
   name: func-deploy
   labels:

--- a/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: Task
+kind: ClusterTask
 metadata:
   name: func-s2i
   labels:
@@ -26,6 +26,7 @@ spec:
       description: Reference of the image S2I will produce.
     - name: REGISTRY
       description: The registry associated with the function image.
+      default: ""
     - name: PATH_CONTEXT
       description: The location of the path to run s2i from.
       default: .

--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -42,6 +42,7 @@ func taskBuildpacks(runAfter []string) pplnv1beta1.PipelineTask {
 		Name: taskNameBuild,
 		TaskRef: &pplnv1beta1.TaskRef{
 			Name: "func-buildpacks",
+			Kind: pplnv1beta1.ClusterTaskKind,
 		},
 		RunAfter: runAfter,
 		Workspaces: []pplnv1beta1.WorkspacePipelineTaskBinding{
@@ -86,6 +87,7 @@ func taskS2iBuild(runAfter []string) pplnv1beta1.PipelineTask {
 		Name: taskNameBuild,
 		TaskRef: &pplnv1beta1.TaskRef{
 			Name: "func-s2i",
+			Kind: pplnv1beta1.ClusterTaskKind,
 		},
 		RunAfter: runAfter,
 		Workspaces: []pplnv1beta1.WorkspacePipelineTaskBinding{
@@ -119,6 +121,7 @@ func taskDeploy(runAfter string, referenceImageFromPreviousTaskResults bool) ppl
 		Name: taskNameDeploy,
 		TaskRef: &pplnv1beta1.TaskRef{
 			Name: "func-deploy",
+			Kind: pplnv1beta1.ClusterTaskKind,
 		},
 		RunAfter: []string{runAfter},
 		Workspaces: []pplnv1beta1.WorkspacePipelineTaskBinding{{


### PR DESCRIPTION
 * Required changes for enabling DevConsole "Create Serverless Function" and "Import from Git".