### PR TITLE
[serverless-1.29.0] devconsole nodejs pipeline hack

### DIFF
--- a/pkg/pipelines/resources/tekton/pipeline/dev-console/0.1/nodejs-pipeline.yaml
+++ b/pkg/pipelines/resources/tekton/pipeline/dev-console/0.1/nodejs-pipeline.yaml
@@ -79,7 +79,7 @@ spec:
         - name: path
           value: $(workspaces.source.path)/$(params.PATH_CONTEXT)
         - name: image
-          value: $(params.IMAGE_NAME)@$(tasks.build.results.IMAGE_DIGEST)
+          value: $(params.IMAGE_NAME):@$(tasks.build.results.IMAGE_DIGEST)
       runAfter:
         - build
       taskRef:


### PR DESCRIPTION
hack to bypass double sha256 error on pipeline. Definitive expected fix on 1.30