### PR TITLE
[serverless-1.29.0] patch s2i task images

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -61,7 +61,7 @@ spec:
       description: Digest of the image just built.
   steps:
     - name: generate
-      image: quay.io/openshift-pipeline/s2i:nightly
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
       args: ["$(params.ENV_VARS[*])"]
       script: |
@@ -100,7 +100,7 @@ spec:
         - mountPath: /env-vars
           name: env-vars
     - name: build
-      image: quay.io/buildah/stable:v1.27.0
+      image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
       workingDir: /gen-source
       script: |
         [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"


### PR DESCRIPTION
Patch s2i task to use supported images referenced on serverless operator