### PR TITLE
[serverless-1.29.0] patch func deploy task for serverless 1.29.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
   e2e-test:
     strategy:
       matrix:
-        go: [1.20.x]
+        go: [1.20.2]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -91,7 +91,7 @@ jobs:
   e2e-on-cluster-test:
     strategy:
       matrix:
-        go: [1.20.x]
+        go: [1.20.2]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-e2e-oncluster-runtime.yaml
+++ b/.github/workflows/test-e2e-oncluster-runtime.yaml
@@ -7,7 +7,7 @@ jobs:
     name: On Cluster RT Test
     strategy:
       matrix:
-        go: [1.20.x]
+        go: [1.20.2]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,6 +22,11 @@ jobs:
         run: ./hack/create-testing-func-image.sh
       - name: Allocate Cluster
         run: ./hack/allocate.sh
+      - name: Install RH pull secrets for KinD cluster
+        env:
+          RH_REG_USR: ${{ secrets.RH_REG_USR }}
+          RH_REG_PWD: ${{ secrets.RH_REG_PWD }}
+        run: ./hack/install-pull-secrets.sh
       - name: Deploy Tekton
         run: ./hack/tekton.sh
       - name: Deploy Test Git Server

--- a/.github/workflows/test-e2e-oncluster.yaml
+++ b/.github/workflows/test-e2e-oncluster.yaml
@@ -7,7 +7,7 @@ jobs:
     name: On Cluster Test
     strategy:
       matrix:
-        go: [1.20.x]
+        go: [1.20.2]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,6 +22,11 @@ jobs:
         run: ./hack/create-testing-func-image.sh
       - name: Allocate Cluster
         run: ./hack/allocate.sh
+      - name: Install RH pull secrets for KinD cluster
+        env:
+          RH_REG_USR: ${{ secrets.RH_REG_USR }}
+          RH_REG_PWD: ${{ secrets.RH_REG_PWD }}
+        run: ./hack/install-pull-secrets.sh
       - name: Deploy Tekton
         run: ./hack/tekton.sh
       - name: Deploy Test Git Server

--- a/.github/workflows/test-e2e-runtime.yaml
+++ b/.github/workflows/test-e2e-runtime.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.x
+          go-version: 1.20.2
       - name: Install Binaries
         run: ./hack/binaries.sh
       - name: Allocate Cluster

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -7,7 +7,7 @@ jobs:
     name: E2E Test
     strategy:
       matrix:
-        go: [1.20.x]
+        go: [1.20.2]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/hack/install-pull-secrets.sh
+++ b/hack/install-pull-secrets.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+main() {
+  local -r tmp_docker_config="$(mktemp config.json-XXXXXXXX)"
+
+  cat <<EOF > "${tmp_docker_config}"
+{
+  "auths": {
+    "registry.redhat.io": {
+      "auth": "$(echo -n "${RH_REG_USR}:${RH_REG_PWD}" | base64 -w0)"
+    }
+  }
+}
+EOF
+
+  local node
+  for node in $(kind get nodes --name "func"); do
+    tar -cf - "${tmp_docker_config}" --transform="flags=r;s|${tmp_docker_config}|config.json|" | \
+      docker cp - "${node}:/var/lib/kubelet/"
+  done
+  rm "${tmp_docker_config}"
+}
+
+main "$@"

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,7 +24,7 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:1700137a4ae6e5c0642faef6b3e037952f985dbe4e9a66916c9a27511833d776"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:8273842d8e1714fa03c7e0809924b1ffc5ef282f79b9606bd8ac88c03e7a16bd"
       env:
         - name: FUNC_IMAGE
           value: "$(params.image)"


### PR DESCRIPTION
patch for func-deploy task to use midstream specific client built for 1.29.1