### PR TITLE
[serverless-1.30.0] patch func deploy task for serverless 1.30.0

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
@@ -24,7 +24,7 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6c553687c1e3102cd5d5a9079a44b2e2e6aefdb46f1062bd0881be67d87eead5"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6b0b0edbdaf491daeaca4bd88a01f2faca9ba677fdfba7f09ec799ed49e81fd1"
       env:
         - name: FUNC_IMAGE
           value: "$(params.image)"

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
@@ -24,7 +24,17 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "ghcr.io/knative/func/func:latest"
-      script: |
-        export FUNC_IMAGE="$(params.image)"
-        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6c553687c1e3102cd5d5a9079a44b2e2e6aefdb46f1062bd0881be67d87eead5"
+      env:
+        - name: FUNC_IMAGE
+          value: "$(params.image)"
+      command:
+        - /ko-app/kn
+      args:
+        - func
+        - deploy
+        - --verbose
+        - --build=false
+        - --push=false
+        - --path=$(params.path)
+        - --remote=false

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,7 +24,7 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6c553687c1e3102cd5d5a9079a44b2e2e6aefdb46f1062bd0881be67d87eead5"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6b0b0edbdaf491daeaca4bd88a01f2faca9ba677fdfba7f09ec799ed49e81fd1"
       env:
         - name: FUNC_IMAGE
           value: "$(params.image)"

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,7 +24,17 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "ghcr.io/knative/func/func:latest"
-      script: |
-        export FUNC_IMAGE="$(params.image)"
-        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6c553687c1e3102cd5d5a9079a44b2e2e6aefdb46f1062bd0881be67d87eead5"
+      env:
+        - name: FUNC_IMAGE
+          value: "$(params.image)"
+      command:
+        - /ko-app/kn
+      args:
+        - func
+        - deploy
+        - --verbose
+        - --build=false
+        - --push=false
+        - --path=$(params.path)
+        - --remote=false


### PR DESCRIPTION
patch for func-deploy task to use midstream specific client built for 1.30.0