### PR TITLE
[serverless-1.30] patch func deploy task for serverless 1.30.1

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
@@ -24,7 +24,7 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6b0b0edbdaf491daeaca4bd88a01f2faca9ba677fdfba7f09ec799ed49e81fd1"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:96de28d4db9962be07e5e8a9669b28fdd078dfc589b0ad57aef755fff33f11b5"
       env:
         - name: FUNC_IMAGE
           value: "$(params.image)"

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,7 +24,7 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6b0b0edbdaf491daeaca4bd88a01f2faca9ba677fdfba7f09ec799ed49e81fd1"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:96de28d4db9962be07e5e8a9669b28fdd078dfc589b0ad57aef755fff33f11b5"
       env:
         - name: FUNC_IMAGE
           value: "$(params.image)"


### PR DESCRIPTION
patch for func-deploy task to use midstream specific client built for 1.30.1