### PR TITLE
[serverless-1.31] patch func deploy task for serverless 1.31.1

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,6 +24,17 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "ghcr.io/knative/func/func:latest"
-      script: |
-        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false --image="$(params.image)"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:3181ad775ead55f317f96466c2719b2b73c5b35d31933733da21273955d160c4"
+      env:
+        - name: FUNC_IMAGE
+          value: "$(params.image)"
+      command:
+        - /ko-app/kn
+      args:
+        - func
+        - deploy
+        - --verbose
+        - --build=false
+        - --push=false
+        - --path=$(params.path)
+        - --remote=false


### PR DESCRIPTION
patch for func-deploy task to use midstream specific client built for 1.31.1