### PR TITLE
[serverless-1.31] patch func deploy task for serverless 1.31.1

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
@@ -22,21 +22,21 @@ spec:
   workspaces:
     - name: source
       description: The workspace containing the function project
-  steps:
-    - name: func-deploy
-      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:e36d4a92e03d35be45d34036a4c0aa3b4ffbe606280ca6bcb43cfa89dbe67abd"
-      env:
-        - name: FUNC_IMAGE
-          value: "$(params.image)"
-        - name: HOME
-          value: "/tmp"
-      command:
-        - /ko-app/kn
-      args:
-        - func
-        - deploy
-        - --verbose
-        - --build=false
-        - --push=false
-        - --path=$(params.path)
-        - --remote=false
+    steps:
+      - name: func-deploy
+        image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:3181ad775ead55f317f96466c2719b2b73c5b35d31933733da21273955d160c4"
+        env:
+          - name: FUNC_IMAGE
+            value: "$(params.image)"
+          - name: HOME
+            value: "/tmp"
+        command:
+          - /ko-app/kn
+        args:
+          - func
+          - deploy
+          - --verbose
+          - --build=false
+          - --push=false
+          - --path=$(params.path)
+          - --remote=false

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,7 +24,7 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:e36d4a92e03d35be45d34036a4c0aa3b4ffbe606280ca6bcb43cfa89dbe67abd"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:3181ad775ead55f317f96466c2719b2b73c5b35d31933733da21273955d160c4"
       env:
         - name: FUNC_IMAGE
           value: "$(params.image)"


### PR DESCRIPTION
patch for func-deploy task to use midstream specific client built for 1.31.1