### PR TITLE
[serverless-1.32] patch func deploy task for serverless 1.32.0

### DIFF
--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy-pac.yaml
@@ -24,7 +24,7 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:aa63566b385616dfd3518aeb26ce192a3374c389a8ce60406289270b59c215f8"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:5121f1657645c4932fb2cf1e85810e5e135dca3a297138c687d827a9e493557d"
       env:
         - name: FUNC_IMAGE
           value: "$(params.image)"

--- a/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -24,6 +24,19 @@ spec:
       description: The workspace containing the function project
   steps:
     - name: func-deploy
-      image: "ghcr.io/knative/func/func:latest"
-      script: |
-        func deploy --verbose --build=false --push=false --path=$(params.path) --remote=false --image="$(params.image)"
+      image: "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:5121f1657645c4932fb2cf1e85810e5e135dca3a297138c687d827a9e493557d"
+      env:
+        - name: FUNC_IMAGE
+          value: "$(params.image)"
+        - name: HOME
+          value: "/tmp"
+      command:
+        - /ko-app/kn
+      args:
+        - func
+        - deploy
+        - --verbose
+        - --build=false
+        - --push=false
+        - --path=$(params.path)
+        - --remote=false


### PR DESCRIPTION
patch for func-deploy task to use midstream specific client built for 1.32.0