### PR TITLE
Changes for oncluster tests on Openshift CI

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,12 @@
+ARG OCP_VERSION=4.16
+ARG GOLANG_VERSION=1.21
+FROM registry.ci.openshift.org/ocp/${OCP_VERSION}:tools as tools
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-${GOLANG_VERSION}-openshift-${OCP_VERSION}
+
+COPY --from=tools /usr/bin/oc /usr/bin/
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
+
+# Reset the goflags to avoid the -mod=vendor flag
+ENV GOFLAGS=
+

--- a/openshift/cluster-prepare.sh
+++ b/openshift/cluster-prepare.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Prepare Cluster on Openshift CI
+# - Creates testing Namespace
+# - Setup Openshift Serverless and Openshift Pipelines
+# - Creates Test GitServer service
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+BASEDIR=$(dirname "$0")
+INSTALL_SERVERLESS="${INSTALL_SERVERLESS:-true}"
+INSTALL_PIPELINES="${INSTALL_PIPELINES:-true}"
+INSTALL_GITSERVER="${INSTALL_GITSERVER:-true}"
+GITSERVER_IMAGE="${GITSERVER_IMAGE:-ghcr.io/jrangelramos/gitserver-unpriv:latest}"
+
+go env
+source "$(go run knative.dev/hack/cmd/script e2e-tests.sh)"
+
+# Prepare Namespace
+TEST_NAMESPACE="${TEST_NAMESPACE:-knfunc-oncluster-test-$(head -c 128 </dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | fold -w 6 | head -n 1)}"
+oc new-project "${TEST_NAMESPACE}" || true
+oc project "${TEST_NAMESPACE}"
+
+# Installs Openshift Serverless
+if [ "$INSTALL_SERVERLESS" == "true" ] ; then
+  header "Installing Openshift Serverless"
+  oc apply -f "${BASEDIR}/deploy/serverless-subscription.yaml"
+  wait_until_pods_running openshift-serverless
+
+  subheader "Installing Serving and Eventing"
+  oc apply -f "${BASEDIR}/deploy/knative-serving.yaml"
+  oc apply -f "${BASEDIR}/deploy/knative-eventing.yaml"
+  oc wait --for=condition=Ready --timeout=10m knativeserving knative-serving -n knative-serving
+  oc wait --for=condition=Ready --timeout=10m knativeeventing knative-eventing -n knative-eventing
+fi
+
+# Installs Openshift Pipelines
+if [ "$INSTALL_PIPELINES" == "true" ] ; then
+  header "Installing Openshift Pipelines"
+  oc apply -f "${BASEDIR}/deploy/pipelines-subscription.yaml"
+  wait_until_pods_running openshift-pipelines
+fi
+
+# Installs Test Git Server
+if [ "$INSTALL_GITSERVER" == "true" ] ; then
+  header "Installing Test GitServer"
+  sed "s!_GITSERVER_IMAGE_!${GITSERVER_IMAGE}!g" "${BASEDIR}/deploy/gitserver-service.yaml" > "${BASEDIR}/deploy/gitserver.yaml"
+  oc apply -f "${BASEDIR}/deploy/gitserver.yaml"
+  oc wait pod/gitserver --for=condition=Ready --timeout=15s
+
+  subheader "Exposing Test GitServer route"
+  oc expose service gitserver --name=gitserver --port=8080
+fi

--- a/openshift/deploy/gitserver-service.yaml
+++ b/openshift/deploy/gitserver-service.yaml
@@ -1,0 +1,28 @@
+# Git Server used by OnCluster tests on Openshift CI
+# Default Image is ghcr.io/jrangelramos/gitserver-unpriv:latest
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: gitserver
+  name: gitserver
+spec:
+  containers:
+    - image: _GITSERVER_IMAGE_
+      name: user-container
+      ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitserver
+spec:
+  type: NodePort
+  selector:
+    app: gitserver
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/openshift/deploy/knative-eventing.yaml
+++ b/openshift/deploy/knative-eventing.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-eventing
+---
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  high-availability:
+    replicas: 1

--- a/openshift/deploy/knative-serving.yaml
+++ b/openshift/deploy/knative-serving.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+---
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  high-availability:
+    replicas: 1

--- a/openshift/deploy/pipelines-subscription.yaml
+++ b/openshift/deploy/pipelines-subscription.yaml
@@ -1,0 +1,12 @@
+# OpenShift Pipelines subscription
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator-rh
+  namespace: openshift-operators
+spec:
+  channel: latest
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/openshift/deploy/serverless-subscription.yaml
+++ b/openshift/deploy/serverless-subscription.yaml
@@ -1,0 +1,24 @@
+# OpenShift Serverless subscription
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-serverless
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: serverless-operators
+  namespace: openshift-serverless
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-serverless
+spec:
+  channel: stable
+  name: serverless-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/openshift/e2e_oncluster_tests.sh
+++ b/openshift/e2e_oncluster_tests.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Runs basic lifecycle E2E tests against kn func cli for a given language/runtime.
+# By default it will run e2e tests against 'func' binary, but you can change it to use 'kn func' instead
+#
+# The following environment variable can be set in order to customize e2e execution:
+#
+# E2E_USE_KN_FUNC    When set to "true" indicates e2e to issue func command using kn cli.
+#
+# E2E_REGISTRY_URL   Indicates a specific registry (i.e: "quay.io/user") should be used. Make sure
+#                    to authenticate to the registry (i.e: docker login ...) prior to execute the script
+#                    By default it uses "ttl.sh" registry
+#
+# E2E_FUNC_BIN_PATH  Path to func binary. Derived by this script when not set
+#
+# E2E_RUNTIMES       List of runtimes (space separated) to execute TestRuntime.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+#source "$(go run knative.dev/hack/cmd/script e2e-tests.sh)"
+
+pushd "$(dirname "$0")/.."
+
+export E2E_REGISTRY_URL="${E2E_REGISTRY_URL:-ttl.sh/knfuncci$(head -c 128 </dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | fold -w 6 | head -n 1)}"
+export E2E_FUNC_BIN_PATH="${E2E_FUNC_BIN_PATH:-$(pwd)/func}"
+export E2E_USE_KN_FUNC="false"
+export E2E_GIT_SERVER_PODNAME="gitserver"
+export E2E_GIT_SERVER_ROUTE_URL="http://$(oc get route gitserver -o jsonpath='{.spec.host}')"
+FUNC_REPO_REF="${FUNC_REPO_REF:-openshift-knative/kn-plugin-func}"
+FUNC_REPO_BRANCH_REF="${FUNC_REPO_BRANCH_REF:-release-next}"
+
+# Ensure 'func' binary is built
+if [[ ! -f "$E2E_FUNC_BIN_PATH" ]]; then
+  echo "building func binary"
+  env FUNC_REPO_REF=${FUNC_REPO_REF} FUNC_REPO_BRANCH_REF=${FUNC_REPO_BRANCH_REF} make build
+fi
+
+# For now, let's skips tests that depends on Podman/Docker on Openshift CI
+if [[ "${OPENSHIFT_CI}" == "true" ]] ; then
+  mv ./test/oncluster/scenario_from-cli-local_test.go ./test/oncluster/scenario_from-cli-local_test.skip
+fi
+
+# Execute on cluster tests (s2i only)
+export FUNC_BUILDER="s2i"
+export FUNC_INSECURE="true"
+go test -timeout 90m -tags="oncluster" ./test/oncluster/
+ret=$?
+
+popd
+exit $ret

--- a/openshift/overrides/test/common/gitserver_openshift.go
+++ b/openshift/overrides/test/common/gitserver_openshift.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"fmt"
+	"os"
+
+	"strings"
+	"testing"
+)
+
+// ------------------------------------------------------
+// Git Server used by Openshift CI. It is deployed os a
+// regular POD with an exposed Route URL.
+// ------------------------------------------------------
+
+type GitTestServerOpenshiftCI struct {
+	PodName  string
+	RouteURL string
+	Kubectl  *TestExecCmd
+	t        *testing.T
+}
+
+var gitServerPodName string
+var gitServerRouteURL string
+
+func init() {
+	// Openshift CI runs `openshift/e2e_oncluster_test.sh` which sets these env vars
+	gitServerPodName = os.Getenv("E2E_GIT_SERVER_PODNAME")
+	gitServerRouteURL = os.Getenv("E2E_GIT_SERVER_ROUTE_URL")
+	if gitServerPodName != "" && gitServerRouteURL != "" {
+		DefaultGitServer = &GitTestServerOpenshiftCI{}
+		fmt.Println("Setting default test git server for CI")
+	}
+}
+
+func (g *GitTestServerOpenshiftCI) Init(T *testing.T) {
+
+	g.PodName = gitServerPodName
+	g.RouteURL = gitServerRouteURL
+	g.t = T
+	if g.Kubectl == nil {
+		g.Kubectl = &TestExecCmd{
+			Binary:              "oc",
+			ShouldDumpCmdLine:   true,
+			ShouldDumpOnSuccess: true,
+			T:                   T,
+		}
+	}
+
+	T.Logf("Initialized HTTP Func Git Server: Server URL = %v Pod Name = %v\n", g.RouteURL, g.PodName)
+}
+
+func (g *GitTestServerOpenshiftCI) CreateRepository(repoName string) *GitRemoteRepo {
+	// kubectl exec gitserver -- git-repo create $reponame
+	cmdResult := g.Kubectl.Exec("exec", g.PodName, "--", "git-repo", "create", repoName)
+
+	if !strings.Contains(cmdResult.Out, "created") {
+		g.t.Fatal("unable to create git bare repository " + repoName)
+	}
+	gitRepo := &GitRemoteRepo{
+		RepoName:         repoName,
+		ExternalCloneURL: g.RouteURL + "/" + repoName + ".git",
+		ClusterCloneURL:  g.RouteURL + "/" + repoName + ".git",
+	}
+	return gitRepo
+}
+
+func (g *GitTestServerOpenshiftCI) DeleteRepository(repoName string) {
+	cmdResult := g.Kubectl.Exec("exec", g.PodName, "--", "git-repo", "delete", repoName)
+	if !strings.Contains(cmdResult.Out, "deleted") {
+		g.t.Fatal("unable to delete git bare repository " + repoName)
+	}
+}


### PR DESCRIPTION
Adding artifacts required to run oncluster e2e tests on Openshift CI (presubmit tests). This PR includes:

- Custom Build Image (w/ `go` and `oc`) used by CI to build and run `func` tests
- Installing script for Serverless, Pipelines and Test GitServer
- Custom script to trigger E2E On Cluster tests
