### PR TITLE
Adding patch script that removes duplicate tests

### DIFF
--- a/openshift/scripts/remove-workflow-tests.sh
+++ b/openshift/scripts/remove-workflow-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# This script is executed during upstream/midstream sync to release-next branch
+# It removes github actions (workflows) executed by Openshift CI
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Covered by https://github.com/openshift/release/blob/master/ci-operator/config/openshift-knative/kn-plugin-func/openshift-knative-kn-plugin-func-release-next.yaml
+rm .github/workflows/test-e2e-oncluster-runtime.yaml
+rm .github/workflows/test-e2e-oncluster.yaml


### PR DESCRIPTION
Script is meant to be executed on each upstream sync to midstream.
It is intended to remove e2e tests now covered on Openshift CI. 