### PR TITLE
[serverless-1.33] fix: PaC build

### DIFF
--- a/pkg/pipelines/tekton/pac/pac.go
+++ b/pkg/pipelines/tekton/pac/pac.go
@@ -26,7 +26,7 @@ const (
 func DetectPACInstallation(ctx context.Context, wantedNamespace string) (bool, string, error) {
 	var installed bool
 
-	clientPac, _, err := NewTektonPacClientAndResolvedNamespace("")
+	clientPac, cns, err := NewTektonPacClientAndResolvedNamespace("")
 	if err != nil {
 		return false, "", err
 	}
@@ -36,7 +36,7 @@ func DetectPACInstallation(ctx context.Context, wantedNamespace string) (bool, s
 		return false, "", err
 	}
 
-	_, err = clientPac.Repositories("").List(ctx, metav1.ListOptions{})
+	_, err = clientPac.Repositories(cns).List(ctx, metav1.ListOptions{})
 	if err != nil && k8serrors.IsNotFound(err) {
 		return false, "", nil
 	}

--- a/pkg/pipelines/tekton/pipelines_pac_provider.go
+++ b/pkg/pipelines/tekton/pipelines_pac_provider.go
@@ -133,7 +133,7 @@ func (pp *PipelinesProvider) createLocalPACResources(ctx context.Context, f fn.F
 // also creates PVC for the function source code
 func (pp *PipelinesProvider) createClusterPACResources(ctx context.Context, f fn.Function, metadata pipelines.PacMetadata) error {
 	// figure out pac installation namespace
-	installed, _, err := pac.DetectPACInstallation(ctx, "openshift-pipelines")
+	installed, _, err := pac.DetectPACInstallation(ctx)
 	if !installed {
 		errMsg := ""
 		if err != nil {
@@ -204,7 +204,7 @@ func (pp *PipelinesProvider) createClusterPACResources(ctx context.Context, f fn
 func (pp *PipelinesProvider) createRemotePACResources(ctx context.Context, f fn.Function, metadata pipelines.PacMetadata) error {
 
 	// figure out pac installation namespace
-	installed, installationNS, err := pac.DetectPACInstallation(ctx, "openshift-pipelines")
+	installed, installationNS, err := pac.DetectPACInstallation(ctx)
 	if !installed {
 		errMsg := ""
 		if err != nil {

--- a/pkg/pipelines/tekton/pipelines_pac_provider.go
+++ b/pkg/pipelines/tekton/pipelines_pac_provider.go
@@ -133,7 +133,7 @@ func (pp *PipelinesProvider) createLocalPACResources(ctx context.Context, f fn.F
 // also creates PVC for the function source code
 func (pp *PipelinesProvider) createClusterPACResources(ctx context.Context, f fn.Function, metadata pipelines.PacMetadata) error {
 	// figure out pac installation namespace
-	installed, _, err := pac.DetectPACInstallation(ctx, "")
+	installed, _, err := pac.DetectPACInstallation(ctx, "openshift-pipelines")
 	if !installed {
 		errMsg := ""
 		if err != nil {
@@ -154,7 +154,12 @@ func (pp *PipelinesProvider) createClusterPACResources(ctx context.Context, f fn
 		labels = pp.decorator.UpdateLabels(f, labels)
 	}
 
-	registry, err := docker.GetRegistry(f.Image)
+	img := f.Deploy.Image
+	if img == "" {
+		img = f.Image
+	}
+
+	registry, err := docker.GetRegistry(img)
 	if err != nil {
 		return fmt.Errorf("problem in resolving image registry name: %w", err)
 	}
@@ -163,7 +168,7 @@ func (pp *PipelinesProvider) createClusterPACResources(ctx context.Context, f fn
 		registry = authn.DefaultAuthKey
 	}
 
-	creds, err := pp.credentialsProvider(ctx, f.Image)
+	creds, err := pp.credentialsProvider(ctx, img)
 	if err != nil {
 		return err
 	}
@@ -199,7 +204,7 @@ func (pp *PipelinesProvider) createClusterPACResources(ctx context.Context, f fn
 func (pp *PipelinesProvider) createRemotePACResources(ctx context.Context, f fn.Function, metadata pipelines.PacMetadata) error {
 
 	// figure out pac installation namespace
-	installed, installationNS, err := pac.DetectPACInstallation(ctx, "")
+	installed, installationNS, err := pac.DetectPACInstallation(ctx, "openshift-pipelines")
 	if !installed {
 		errMsg := ""
 		if err != nil {


### PR DESCRIPTION
* Fixed detection of PaC controller URL for unprivileged users.
* Use `fn.Deploy.Image` before `fn.Image` since the `fn.Image` may not be populated.