### PR TITLE
update base builder image for openshift CI

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,4 +1,4 @@
-ARG OCP_VERSION=4.16
+ARG OCP_VERSION=4.17
 ARG GOLANG_VERSION=1.22
 FROM registry.ci.openshift.org/ocp/${OCP_VERSION}:tools as tools
 
@@ -8,5 +8,4 @@ COPY --from=tools /usr/bin/oc /usr/bin/
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 # Reset the goflags to avoid the -mod=vendor flag
-ENV GOFLAGS=
-
+ENV GOFLAGS=''


### PR DESCRIPTION
This PR updates the base image used to run Openshift CI (prow) jobs. Reaharsal using this new image can be found on this testing-only PR https://github.com/openshift/release/pull/53384
 - Test execution [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/53384/rehearse-53384-pull-ci-jrangelramos-func-presubmit-e2e-oncluster-test/1803521014101970944) 
 - Test Result [log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/53384/rehearse-53384-pull-ci-jrangelramos-func-presubmit-e2e-oncluster-test/1803521014101970944/artifacts/e2e-oncluster-test/test/build-log.txt)