### PR TITLE
Use RHEL 8 for builder base for func-util image

### DIFF
--- a/openshift/scripts/generate-dockerfiles.sh
+++ b/openshift/scripts/generate-dockerfiles.sh
@@ -26,6 +26,6 @@ install_generate_hack_tool || exit 1
 "$(go env GOPATH)"/bin/generate \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
-  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-%s-openshift-4.17" \
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17" \
   --includes cmd/func-util \
   --template-name "func-util"


### PR DESCRIPTION
Use RHEL 8 for builder base for func-util image as we use UBI8 for the runtime image too.