### PR TITLE
Force fetching upstream tags to not complain about existing tags with same name in origin

### DIFF
--- a/openshift/release/mirror-upstream-branches.sh
+++ b/openshift/release/mirror-upstream-branches.sh
@@ -23,7 +23,7 @@ set -exo pipefail
 TMPDIR=$(mktemp -d knativeFuncBranchingCheckXXXX -p /tmp/)
 readonly TMPDIR
 
-git fetch upstream --tags
+git fetch upstream --tags --force # use force to not complain about existing tags with same name in origin
 git fetch openshift
 
 # Ignore release 1.7-1.14 and only sync starting from 1.15


### PR DESCRIPTION
Fixing [knative-nightly-ci-kn-plugin-func/1192](https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-kn-plugin-func/1192/console) as discussed in [Slack](https://redhat-internal.slack.com/archives/CLMP7R2G2/p1726499246343339)