### PR TITLE
Exclude 1.15 from upstream branch mirroring

### DIFF
--- a/openshift/release/mirror-upstream-branches.sh
+++ b/openshift/release/mirror-upstream-branches.sh
@@ -36,6 +36,7 @@ cat >> "$TMPDIR"/midstream_branches <<EOF
 1.12
 1.13
 1.14
+1.15
 EOF
 
 git branch --list -a "upstream/release-1.*" | cut -f3 -d'/' | cut -f2 -d'-' > "$TMPDIR"/upstream_branches


### PR DESCRIPTION
As per title (as discussed in [slack](https://redhat-internal.slack.com/archives/CLMP7R2G2/p1726587662839889?thread_ts=1726579492.799329&cid=CLMP7R2G2))