### PR TITLE
[release-v1.15] Fixes

### DIFF
--- a/cmd/repository_test.go
+++ b/cmd/repository_test.go
@@ -33,7 +33,7 @@ func TestRepository_List(t *testing.T) {
 // arguments, respects the repositories' path flag, and the expected name is echoed
 // upon subsequent 'list'.
 func TestRepository_Add(t *testing.T) {
-	url := ServeRepo("repository.git#main", t)
+	url := ServeRepo("repository.git", t) + "#main"
 	_ = FromTempDirectory(t)
 	t.Log(url)
 

--- a/pkg/functions/repositories_test.go
+++ b/pkg/functions/repositories_test.go
@@ -179,7 +179,7 @@ func TestRepositories_AddWithManifest(t *testing.T) {
 	// defines a custom language pack and makes full use of the manifest.yaml.
 	// The manifest.yaml is included which specifies things like custom templates
 	// location and (appropos to this test) a default name/
-	uri := ServeRepo("repository-a", t) // ./testdata/repository-a.git
+	uri := ServeRepo("repository-a.git", t) // ./testdata/repository-a.git
 	root, rm := Mktemp(t)
 	defer rm()
 

--- a/pkg/oci/containerize_test.go
+++ b/pkg/oci/containerize_test.go
@@ -1,6 +1,8 @@
 package oci
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -10,7 +12,16 @@ import (
 // links which are absolute or refer to targets outside the given root, in
 // addition to the basic job of returning the value of reading the link.
 func Test_validatedLinkTarget(t *testing.T) {
-	root := "testdata/test-links"
+	root := filepath.Join("testdata", "test-links")
+
+	err := os.Symlink("/var/example/absolute/link", filepath.Join(root, "absoluteLink"))
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		t.Fatal(err)
+	}
+	err = os.Symlink("c://some/absolute/path", filepath.Join(root, "absoluteLinkWindows"))
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		t.Fatal(err)
+	}
 
 	// Windows-specific absolute link and link target values:
 	absoluteLink := "absoluteLink"

--- a/pkg/oci/testdata/test-links/absoluteLink
+++ b/pkg/oci/testdata/test-links/absoluteLink
@@ -1,1 +1,0 @@
-/var/example/absolute/link

--- a/pkg/oci/testdata/test-links/absoluteLinkWindows
+++ b/pkg/oci/testdata/test-links/absoluteLinkWindows
@@ -1,1 +1,0 @@
-c://some/absolute/path

--- a/pkg/pipelines/tekton/tasks.go
+++ b/pkg/pipelines/tekton/tasks.go
@@ -286,6 +286,7 @@ spec:
       description: Reference of the image S2I will produce.
     - name: REGISTRY
       description: The registry associated with the function image.
+      default: ""
     - name: PATH_CONTEXT
       description: The location of the path to run s2i from.
       default: .

--- a/pkg/pipelines/tekton/templates_s2i.go
+++ b/pkg/pipelines/tekton/templates_s2i.go
@@ -174,12 +174,6 @@ metadata:
     # Fetch the git-clone task from hub
     pipelinesascode.tekton.dev/task: {{.GitCloneTaskRef}}
 
-    # Fetch the func-s2i task
-    pipelinesascode.tekton.dev/task-1: {{.FuncS2iTaskRef}}
-
-    # Fetch the func-deploy task
-    pipelinesascode.tekton.dev/task-2: {{.FuncDeployTaskRef}}
-
     # Fetch the pipelie definition from the .tekton directory
     pipelinesascode.tekton.dev/pipeline: {{.PipelineYamlURL}}
 

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -17,6 +17,8 @@ package testing
 
 import (
 	"fmt"
+	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/http/cgi"
@@ -136,14 +138,57 @@ func cd(t *testing.T, dir string) {
 // such as fromTempDirectory(t)
 func ServeRepo(name string, t *testing.T) string {
 	t.Helper()
-	var (
-		path   = filepath.Join("./testdata", name)
-		dir    = filepath.Dir(path)
-		abs, _ = filepath.Abs(dir)
-		repo   = filepath.Base(path)
-		url    = RunGitServer(abs, t)
-	)
-	return fmt.Sprintf("%v/%v", url, repo)
+
+	gitRoot := t.TempDir()
+
+	// copy repo to the temp dir
+	err := filepath.Walk(filepath.Join("./testdata", name), func(path string, fi fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relp, err := filepath.Rel("./testdata", path)
+		if err != nil {
+			return fmt.Errorf("cannot get relpath: %v", err)
+		}
+
+		dest := filepath.Join(gitRoot, relp)
+
+		switch {
+		case fi.Mode().IsRegular():
+			var in, out *os.File
+			in, err = os.Open(path)
+			if err != nil {
+				return fmt.Errorf("cannot open source file: %v", err)
+			}
+			defer in.Close()
+			out, err = os.OpenFile(dest, os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				return fmt.Errorf("cannot open destination file: %v", err)
+			}
+			defer out.Close()
+			_, err = io.Copy(out, in)
+			if err != nil {
+				return fmt.Errorf("cannot copy data: %v", err)
+			}
+		case fi.IsDir():
+			err = os.MkdirAll(dest, 0755)
+			if err != nil {
+				return fmt.Errorf("cannot mkdir: %v", err)
+			}
+		default:
+			return fmt.Errorf("unsupported file type")
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	url := RunGitServer(gitRoot, t)
+
+	return fmt.Sprintf("%v/%v", url, name)
 }
 
 // WithExecutable creates an executable of the given name and source in a temp

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -21,8 +21,8 @@ arches:
     packages:
       - repoid: ubi-8-appstream-rpms
         url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/s/socat-1.7.4.1-1.el8.aarch64.rpm"
-        size: 320544
-        checksum: "sha256:4e8380ed4b4570663136b8b499bfe343b688bda676028ef5172d2155ac80e6ae"
+        size: 324364
+        checksum: "sha256:eb27326c2f3f7c813f0f21e15177ab3f4c74778e2ef8029de51aafb09445c515"
       - repoid: ubi-8-baseos-rpms
         url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/t/tar-1.30-9.el8.aarch64.rpm"
         size: 849892


### PR DESCRIPTION
* Fixed konflux symlink error. Some tools dislike having questionable symlinks in git repository so we must create these symlinks dynamically in the test instead of having it committed into the repository.

* Picked https://github.com/openshift-knative/kn-plugin-func/pull/917

* Picked https://github.com/openshift-knative/kn-plugin-func/pull/922

* Fixed socat rpm size/hash

* Picked https://github.com/knative/func/pull/2503