### PR TITLE
Fix symlink path separators

### DIFF
--- a/pkg/builders/s2i/builder.go
+++ b/pkg/builders/s2i/builder.go
@@ -295,7 +295,7 @@ func (b *Builder) Build(ctx context.Context, f fn.Function, platforms []fn.Platf
 				}
 			}
 
-			hdr, err := tar.FileInfoHeader(fi, lnk)
+			hdr, err := tar.FileInfoHeader(fi, filepath.ToSlash(lnk))
 			if err != nil {
 				return fmt.Errorf("cannot create tar header: %w", err)
 			}

--- a/pkg/pipelines/tekton/pipelines_provider.go
+++ b/pkg/pipelines/tekton/pipelines_provider.go
@@ -336,7 +336,7 @@ func sourcesAsTarStream(f fn.Function) *io.PipeReader {
 				}
 			}
 
-			hdr, err := tar.FileInfoHeader(fi, lnk)
+			hdr, err := tar.FileInfoHeader(fi, filepath.ToSlash(lnk))
 			if err != nil {
 				return fmt.Errorf("cannot create a tar header: %w", err)
 			}


### PR DESCRIPTION
When running on Windows the path separators in symlink target is backslash. This must be fixed up when uploading source code into docker daemon or into cluster volume.