### PR TITLE
Update CI images base

### DIFF
--- a/openshift/scripts/generate-dockerfiles.sh
+++ b/openshift/scripts/generate-dockerfiles.sh
@@ -26,6 +26,6 @@ install_generate_hack_tool || exit 1
 "$(go env GOPATH)"/bin/generate \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
-  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17" \
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.19" \
   --includes cmd/func-util \
   --template-name "func-util"


### PR DESCRIPTION
Update CI images base to use OCP 4.19 because older OCP images do not have Go 1.23.