### PR TITLE
[release-v1.15] Disable syft github-actions-usage-cataloger

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,2 @@
+select-catalogers:
+- -github-actions-usage-cataloger


### PR DESCRIPTION
In Konflux we see in the release pipelines the [push-rpm-data-to-pyxis](https://console.redhat.com/application-pipeline/workspaces/rhtap-releng/applications/serverless-operator-135/taskruns/managed-cmzcd-push-rpm-data-to-pyxis) task failing due to:

```
[push-rpm-data-to-pyxis] Uploading RPM data to Pyxis for IMAGE: 674ef915ae22408fb8de8780 with SBOM: 674ef915ae22408fb8de8780.json using script: upload_rpm_data_cyclonedx
[push-rpm-data-to-pyxis] Uploading RPM data to Pyxis for IMAGE: 674ef922ae22408fb8de87b7 with SBOM: 674ef922ae22408fb8de87b7.json using script: upload_rpm_data_cyclonedx
[push-rpm-data-to-pyxis] Uploading RPM data to Pyxis for IMAGE: 674ef92bae22408fb8de87c4 with SBOM: 674ef92bae22408fb8de87c4.json using script: upload_rpm_data_cyclonedx
[push-rpm-data-to-pyxis] Uploading RPM data to Pyxis for IMAGE: 674ef934ae22408fb8de87e2 with SBOM: 674ef934ae22408fb8de87e2.json using script: upload_rpm_data_cyclonedx
[push-rpm-data-to-pyxis] Waiting for the current batch of background processes to finish
[push-rpm-data-to-pyxis] Error: upload of rpm data failed for one of the images
[push-rpm-data-to-pyxis] Error: upload of rpm data failed for one of the images
[push-rpm-data-to-pyxis] Error: upload of rpm data failed for one of the images
[push-rpm-data-to-pyxis] Error: upload of rpm data failed for one of the images
[push-rpm-data-to-pyxis] 
[push-rpm-data-to-pyxis] Printing outputs for current upload_rpm_data script runs
[push-rpm-data-to-pyxis] === 674ef915ae22408fb8de8780 ===
[push-rpm-data-to-pyxis] 2024-12-05 10:42:07,780 [upload_rpm_data] DEBUG Image ID: 674ef915ae22408fb8de8780
[push-rpm-data-to-pyxis] 2024-12-05 10:42:07,780 [upload_rpm_data] DEBUG Pyxis GraphQL API: https://graphql-pyxis.preprod.api.redhat.com/graphql/
[push-rpm-data-to-pyxis] 2024-12-05 10:42:07,795 [upload_rpm_data] INFO Loaded 3096 components from sbom file.
[push-rpm-data-to-pyxis] Traceback (most recent call last):
[push-rpm-data-to-pyxis]   File "/home/pyxis/upload_rpm_data_cyclonedx", line 321, in <module>
[push-rpm-data-to-pyxis]     main()
[push-rpm-data-to-pyxis]   File "/home/pyxis/upload_rpm_data_cyclonedx", line 315, in main
[push-rpm-data-to-pyxis]     upload_container_rpm_data_with_retry(args.pyxis_graphql_api, image_id, args.sbom_path)
[push-rpm-data-to-pyxis]   File "/home/pyxis/upload_rpm_data_cyclonedx", line 49, in upload_container_rpm_data_with_retry
[push-rpm-data-to-pyxis]     upload_container_rpm_data(graphql_api, image_id, sbom_path)
[push-rpm-data-to-pyxis]   File "/home/pyxis/upload_rpm_data_cyclonedx", line 70, in upload_container_rpm_data
[push-rpm-data-to-pyxis]     rpms, content_sets = construct_rpm_items_and_content_sets(sbom_components)
[push-rpm-data-to-pyxis]   File "/home/pyxis/upload_rpm_data_cyclonedx", line 259, in construct_rpm_items_and_content_sets
[push-rpm-data-to-pyxis]     purl_dict = PackageURL.from_string(component["purl"]).to_dict()
[push-rpm-data-to-pyxis]   File "/usr/local/lib/python3.9/site-packages/packageurl/__init__.py", line 508, in from_string
[push-rpm-data-to-pyxis]     raise ValueError(msg)
[push-rpm-data-to-pyxis] ValueError: Invalid purl 'pkg:github/docker:/#docker.mirror.hashicorp.services/rhysd/actionlint:latest' cannot contain a "user:pass@host:port" URL Authority component: ''.
```

According to the discussion in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1733406819412889, we need to disable the `github-actions-usage-cataloger` syft cataloger for the func-utils Konflux component.