### PR TITLE
[release-v1.16] bump Dockerfile.utils to go 1.23

### DIFF
--- a/Dockerfile.utils
+++ b/Dockerfile.utils
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM index.docker.io/library/golang:1.22.1-alpine3.19 AS builder
+FROM --platform=$BUILDPLATFORM index.docker.io/library/golang:1.23.4-alpine3.19 AS builder
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM


### PR DESCRIPTION
because of 
https://github.com/openshift-knative/kn-plugin-func/pull/1263
and specifically
https://github.com/openshift-knative/kn-plugin-func/actions/runs/14621014533/job/41020773856?pr=1263