### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-plugin-func-func-util-115

### DIFF
--- a/openshift/ci-operator/knative-images/func-util/Dockerfile
+++ b/openshift/ci-operator/knative-images/func-util/Dockerfile
@@ -38,6 +38,7 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Kn Plugin Func Func Util" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Kn Plugin Func Func Util" \
       io.k8s.description="Red Hat OpenShift Serverless Kn Plugin Func Func Util" \
-      io.openshift.tags="func-util"
+      io.openshift.tags="func-util" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8"
 
 ENTRYPOINT ["/usr/bin/bash"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
