### PR TITLE
[release-v1.21] test: mask setgid mode bit for sake of OCP

### DIFF
--- a/pkg/functions/templates_test.go
+++ b/pkg/functions/templates_test.go
@@ -356,7 +356,7 @@ func TestTemplates_ModeRemote(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file.Mode() != os.ModeDir|0755 {
+	if (file.Mode() &^ os.ModeSetgid) != os.ModeDir|0755 {
 		t.Fatalf("The remote repositry directory mode should be 0755 but was %#o", file.Mode())
 	}
 


### PR DESCRIPTION
On prow test the `setgid` bit is set on FS so it badly interacts with tests.